### PR TITLE
Update Google Webfont

### DIFF
--- a/demo-widget-groups/widget-group-2018-06-vca-url.html
+++ b/demo-widget-groups/widget-group-2018-06-vca-url.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
-    <link href="https://fonts.googleapis.com/css?family=Play" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Play" rel="stylesheet">
     <title>betterplace.org</title>
     <style>
       body {

--- a/src/components/DonationList.jsx
+++ b/src/components/DonationList.jsx
@@ -34,7 +34,7 @@ export const DonationList = (props) => {
 
   return <>
     <link rel="stylesheet" href="https://www.betterplace.org/de/layouts/current_stylesheet/application" />
-    <link href="https://fonts.googleapis.com/css?family=Fira+Sans&amp;display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Sans&amp;display=swap" rel="stylesheet" />
 
     <div className='container'>
       <div className='row'>

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -36,7 +36,7 @@ export const List = (props) => {
   </ul>
 
   return <>
-    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono&amp;display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono&amp;display=swap" rel="stylesheet" />
     <div>
     {props.listData.map((data) => {
       if (!data.id) return null

--- a/src/tools/__tests__/buildGoogleWebfontUrl.test.js
+++ b/src/tools/__tests__/buildGoogleWebfontUrl.test.js
@@ -1,0 +1,52 @@
+import { buildGoogleWebfontUrl } from '../styled'
+
+describe('buildGoogleWebfontUrl', () => {
+
+  it('returns no URL if fontFamily is missing', () => {
+    const url = buildGoogleWebfontUrl(null, null)
+    expect(url).toEqual('')
+  })
+
+  describe('with fontFamily present', () => {
+    const baseUrl = 'https://fonts.googleapis.com/css2'
+
+    it('returns a correct URL if fontWeight=null AKA (intentionally) missing', () => {
+      const url = buildGoogleWebfontUrl('Fira Sans', null)
+      expect(url).toEqual(`${baseUrl}?family=Fira+Sans`)
+    })
+
+    it('returns a correct URL with fontWeight=100 – a correct weight', () => {
+      const url = buildGoogleWebfontUrl('Fira Sans', 100)
+      expect(url).toEqual(`${baseUrl}?family=Fira+Sans:wght@100`)
+    })
+
+    it('returns a broken URL with fontWeight=33 – an incorrect weight', () => {
+      const url = buildGoogleWebfontUrl('Fira Sans', 33)
+      expect(url).toEqual(`${baseUrl}?family=Fira+Sans:wght@33`)
+      // We don't catch this case since it will clearly fail (font does not show),
+      // and we could only validate the weight by checking with the GoogleWebfonts API first.
+    })
+
+    it('returns a correct URL with fontWeight="light"', () => {
+      const url = buildGoogleWebfontUrl('Fira Sans', "light")
+      expect(url).toEqual(`${baseUrl}?family=Fira+Sans:wght@300`)
+    })
+
+    it('returns a correct URL with fontWeight="bold"', () => {
+      const url = buildGoogleWebfontUrl('Fira Sans', "bold")
+      expect(url).toEqual(`${baseUrl}?family=Fira+Sans:wght@700`)
+    })
+
+    it('returns a correct URL with fontWeight="regular" – intentional fallback', () => {
+      // "regular" is what the GoogleWebfont API gives us and therefore our configurator uses.
+      const url = buildGoogleWebfontUrl('Fira Sans', "regular")
+      expect(url).toEqual(`${baseUrl}?family=Fira+Sans:wght@400`)
+    })
+
+    it('returns a correct URL with fontWeight="Some String" – general fallback', () => {
+      const url = buildGoogleWebfontUrl('Fira Sans', "Some String")
+      expect(url).toEqual(`${baseUrl}?family=Fira+Sans:wght@400`)
+    })
+  })
+
+})

--- a/src/tools/styled.js
+++ b/src/tools/styled.js
@@ -24,24 +24,47 @@ function extractPixelFromParams(name, params, defaultValue) {
   return (params.has(name) && parseInt(params.get(name), 10)) || defaultValue
 }
 
+export function buildGoogleWebfontUrl(fontFamily, fontWeight) {
+  if (!fontFamily) return ''
+
+  // For the GoogleFonts Api, we need fontWeight as number.
+  // This takes care of possible legacy values out there.
+  let fontWeightAsNumber
+  switch (fontWeight) {
+    case 'bold':
+      fontWeightAsNumber = 700
+      break;
+    case 'light':
+      fontWeightAsNumber = 300
+      break;
+    default:
+      fontWeightAsNumber = Number.parseInt(fontWeight) || 400
+  }
+
+  const fontFamilyForUrl = `?family=${fontFamily.replace(/ /g, '+')}`
+  const fontWeightForUrl = fontWeight ? `:wght@${fontWeightAsNumber}` : ''
+
+  return `https://fonts.googleapis.com/css2${fontFamilyForUrl}${fontWeightForUrl}`
+}
+
 function googleFontsImport(params) {
   const fontFamily = extractFromParams('fontFamily', params, null)
-  const fontWeight = extractFromParams('fontWeight', params, 'normal')
+  const fontWeight = extractFromParams('fontWeight', params, null)
 
   if (fontFamily) {
     return `
-      @import url('https://fonts.googleapis.com/css?family=${fontFamily.replace(/ /g, '+')}:${fontWeight}');
+      @import url('${buildGoogleWebfontUrl(fontFamily, fontWeight)}');
 
       body {
         font-family: ${fontFamily.replace(/\+/g, ' ')};
-        font-weight: ${fontWeight};
+        font-weight: ${fontWeight || 'normal'};
       }
     `
   } else {
     return `
       body {
         font-family: Verdana;
-        font-weight: ${fontWeight};
+        font-weight: ${fontWeight || 'normal'};
       }
     `
   }


### PR DESCRIPTION
Google Webfonts has a new API (https://developers.google.com/fonts/docs/css2) that changes the URL (from `/css` to `/css2`) and the way fontWeight are specified.

They also only use numbers to specify their fontWeights in the URL. However, our configuration code does allow and suggest adding strings as fontWeight url param. Therefore, the script transforms those strings to fitting weight-values. This is also needed for the weight information we pulled from the googleWebfont API itself (for our configuration UI), which also includes 'regular' instead of 400.