### PR TITLE
[DEV-12292] Only take textColor into account if withoutBackgroundImage is true for standard widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ https://streambot.betterplace.org/fundraising-events/<ID>/standard
 Customization parameters:
 
 - `withoutBackgroundImage=true` - hides the betterplace background image
-- `textColor` - hex color value (without #), e.g. `&textColor=ff0000`
+- `textColor` - hex color value (without #) that only affects the text color of standard widgets without background image, e.g. `&textColor=ff0000`
 - `demo` - show demo data instead of actual data (useful for testing) - e.g. `&demo=true`
 
 ### Progress bar

--- a/src/components/preconfigured/Standard.tsx
+++ b/src/components/preconfigured/Standard.tsx
@@ -8,7 +8,10 @@ export const Standard = (props: WidgetProps) => {
   const params = new URLSearchParams(props.location.search)
   const demo = params.has('demo')
   const backgroundImage = params.get('withoutBackgroundImage') === 'true' ? null : defaultBackgroundImage
-  const textColor = params.get('textColor') || 'fff'
+  let textColor = 'ffffff'
+  if (params.get('withoutBackgroundImage') === 'true') {
+    textColor = params.get('textColor') || 'ffffff'
+  }
 
   return (
     <>


### PR DESCRIPTION
* Text color is always white when background image is displayed