### PR TITLE
[DEV-22408] remove the hardcoded font from being used in amount

### DIFF
--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -18,10 +18,7 @@ const ListNickname = ({ name, color }: { name: string; color: string }) => {
 }
 
 const Amount = ({ amount, params }: { amount: number; params: URLSearchParams }) => {
-  const style = {
-    fontFamily: 'Roboto Mono',
-  }
-  return <div style={style}>{formatCents(amount, params)}</div>
+  return <div>{formatCents(amount, params)}</div>
 }
 
 type ListData = {


### PR DESCRIPTION
DEV-22408

Removed the hardcoded font from being used in the amount. We should use the same font as the other elements and was picked in the stream widget configuration.